### PR TITLE
Cache only downloads, fix python helper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -515,12 +515,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PYTHON_HELPER_DIR='/usr/local/src/python-netcdf-helper'
 
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip3 install --upgrade pip wheel setuptools
-
 COPY ./python "${PYTHON_HELPER_DIR}/"
+RUN chmod 0755 "${PYTHON_HELPER_DIR}/pip3-netcdf-install.sh" \
+    && ln -s "${PYTHON_HELPER_DIR}/pip3-netcdf-install.sh" /usr/local/bin/pip3-netcdf-install
 
+ARG PYTHON_NETCDF_INSTALL="NO"
 RUN --mount=type=cache,target=/root/.cache/pip \
-    chmod 0755 "${PYTHON_HELPER_DIR}/pip3-netcdf-install.sh" \
-    && ln -s "${PYTHON_HELPER_DIR}/pip3-netcdf-install.sh" /usr/local/bin/pip3-netcdf-install \
-    && pip3-netcdf-install
+    if [[ "${PYTHON_NETCDF_INSTALL}}" == "YES" ]]; then pip3-netcdf-install; fi

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Docker base image definition for an environment that includes specific versions 
 
 - [Installed Software Versions](#installed-software-versions)
 - [Usage Example](#usage-example)
+- [Helper Script for Python Developers](#helper-script-for-python-developers)
+- [Multistage Build](#multistage-build)
 
 &nbsp;
 
@@ -15,7 +17,7 @@ Pre-compiled Docker images have been configured by the [CSIRO Coastal Informatic
 
 - `debian:12-slim`
 - `python:3.11-slim-bookworm`
-- `rocker/r-ver:4`
+- `ems`  (this one includes the library versions known to work with CSIRO's [Environmental Modelling Suite (EMS)](https://github.com/csiro-coasts/EMS))
 
 If you have need for a pre-built image that uses a different base image, please [raise a ticket](https://github.com/eReefs/netcdf-base/issues), and we will see what we can do.
 
@@ -63,6 +65,42 @@ docker build --pull \
   --tag "onaci/ereefs-netcdf-base:$(echo $BASE_IMAGE | tr ':' '-' | tr '/' '-')"
 ```
 
-Installing all these packages from source is NOT a speedy operation, so be prepared for this build to take up to several hours.
+Installing all these packages from source is NOT a speedy operation, so be prepared for this build to take up to several hours!
 
 &nbsp;
+
+
+## Helper Script for Python Developers
+
+To assist developers who are using this image as a base-image for a Python application, the image includes a helper-script at `/usr/local/bin/pip3-netcdf-install` which can be used to force the `netcdf4`, `gdal`, `nco`, `pydap` and `pyproj` python packages to compile their own wheels linked against the pre-installed C and C++ libraries in this image.
+
+You should use this instead of just `pip` or `pip3` when installing your Python requirements like so:
+
+```bash
+pip3-netcdf-install /path/to/your/requirements.txt
+```
+
+Without this script (or similar care), you will find that your `pip install` steps download and install their own pre-packaged versions of `libnetcdf` or `libgdal` or similar, and those versions will not be the ones you expect or have the non-standard options like parallel-IO support.
+
+
+## Multistage Build
+
+Because of the long build times, this [Dockerfile](./Dockerfile) is set up as a multistage build, with one stage per library.  This allows developers to selectively end the build at any point with only a subset of libraries installed,
+which can speed things up if you are debugging a particular library, or don't need downstream libraries (e.g. `gdal`...) in your final image.
+
+The build stages in order are:
+
+- `base` => just the base image with updates applied.
+- `curl` => `CURL_VERSION` of libcurl and curl installed.
+- `dap` => `DAP_VERSION` of libdap installed.
+- `hdf5` => `HDF5_VERSION` of libhdf5 installed.
+- `s3` => `AWS_SDK_CPP_REFSPEC` branch/tag of the Amazon S3 C++ SDK installed.
+- `netcdf` => `NETCDF_VERSION` of the netCDF-C libarary (libnetcdf) and related utilities installed and linked against the libdap, libhdf5 and AWS S3 C++ SDK installed previously.
+- `nco` => `NCO_VERSION` of the NetCDF Operators (NCO Tools) installed and linked against the netCDF-C library installed previously.
+- `proj` => `PROJ_VERSION` of libproj and proj installed.
+- `geos` => `GEOS_VERSION` of the libgeos installed.
+- `geotiff` => `GEOTIFF_VERSION` of libgeotiff installed, linked against the version of libproj installed previously.
+- `gdal` => `GDAL_VERSION` of GDAL installed, linked against the versions of libcurl, libhdf5, libnetcdf, libproj, libgeos and libgeotiff installed previously.
+- `python` => `pip3-netcdf-install` helper script installed.
+
+To stop the build after any particular stage, include `--target=<stage>` in your build command.

--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ The values of these arguments will be available to derived images in environment
 | `HDF5_VERSION` | The version of the HDF 5 library (`libhdf5-dev`) that should be compiled for testing. This will be compiled with support for parallel I/O with MPI (`--enable-parallel`), for thread-safe operation (`--enable-threadsafe`) and for AWS S3 file storage (`--enable-ros3-vfd`).  <https://portal.hdfgroup.org/display/HDF5/HDF5> | `1.14.0` [released 2023-02-08](https://support.hdfgroup.org/ftp/HDF5/releases/) | `org.hdfgroup.hdf5.version` |
 | `AWS_SDK_CPP_REFSPEC` | The git branch or tag of the S3 library from the AWS C++ SDK that you want the NetCDF library to depend on. (Note: This SDK does not have formal release versions, only tags).  <https://github.com/aws/aws-sdk-cpp> | `main` (the latest available at the time of building) | `com.amazonaws.sdk.version` |
 | `NETCDF_VERSION` | The version of the netCDF-C library that should be installed. The library will be linked against the results of your `DAP_VERSION`, `HDF5_VERSION` and `AWS_SDK_CPP_REFSPEC` selections, and with support for parallel I/O, NcZarr files and byte-range queries to files on AWS S3 storage.  <https://docs.unidata.ucar.edu/netcdf-c/current/index.html> | `4.9.2` [released 2023-03-14](https://github.com/Unidata/netcdf-c/releases) | `edu.ucar.unidata.netcdf.version` |
+| `NETCDF_PATCH` | Whether a patch for [this known NetCDF-C issue](https://github.com/Unidata/netcdf-c/issues/2674) should be applied to the NetCDF C library's source code. Set it to any other value to disable patching (e.g. if the patch doesn't apply cleanly for your `NETCDF_VERSION`). | `YES` | |
 | `NCO_VERSION` | The version of the NetCDF Operators (NCO) that should be installed. These will be compiled against your choice of NetCDF library. <https://sourceforge.net/projects/nco/> | `5.1.7`, [released 2023-07-27](https://github.com/nco/nco/releases) | `net.sf.nco.version` |
 | `PROJ_VERSION` | The version of the PROJ library (`proj-bin, libproj-dev`) to install.  This depends on your CURL_VERSION, and is a prerequisite for GDAL. <https://proj.org/en/stable/index.html> | `9.2.1` [released 3023-06-01](https://proj.org/en/stable/download.html) | `org.proj.version` |
 | `GDAL_VERSION` | The version of GDAL that should be installed.   This will be compiled with support for (at minimum) geotiff, gif, hdf5, jpeg, json, netcdf, spatialite, sqlite, tiff and zarr, and will be linked against your chosen PROJ, HDF5 and NetCDF library versions.  It may also build with python or java bindings if those were pre-installed in your base image. <https://gdal.org/> | `3.7.2` [released 2023-09-13](https://gdal.org/download.html) | `org.gdal.version` |
+| `PYTHON_NETCDF_INSTALL` | Set this to `YES` if you want to pre-install python libraries (via pip3) that work with the C and C++ libraries we have installed from source. | `NO` | |
 
 
 &nbsp;
@@ -81,6 +83,11 @@ pip3-netcdf-install /path/to/your/requirements.txt
 ```
 
 Without this script (or similar care), you will find that your `pip install` steps download and install their own pre-packaged versions of `libnetcdf` or `libgdal` or similar, and those versions will not be the ones you expect or have the non-standard options like parallel-IO support.
+
+By default, this script is only installed during the image build, not run: this allows your own derived image
+to run it with your own set of library version constraints.
+
+To run it with a default set of library versions during the build, set the `PYTHON_NETCDF_INSTALL` build argument to a value of `YES`.
 
 
 ## Multistage Build

--- a/hooks/build
+++ b/hooks/build
@@ -6,12 +6,12 @@ if [ -f .env ]; then
 fi
 
 # Derive some more variables from the dockerhub build environment
+BUILD_TARGET="python"
 BUILD_TIMESTAMP="$(date --rfc-3339=seconds)"
 DOCKER_TAG="${DOCKER_TAG:-}"
 SAFE_TIMESTAMP="$(echo $BUILD_TIMESTAMP | sed 's/ /T/g' | sed 's/:/-/g' | sed 's/\+.*//')"
 SOURCE_URL="$(git remote get-url origin || true)"
 VERSION_TAG="${SOURCE_BRANCH}_v${SAFE_TIMESTAMP}-${SOURCE_COMMIT}"
-
 
 # Treat most DOCKER_TAG values as overrides for the
 # BASE_IMAGE variable sourced from the .env file
@@ -22,16 +22,13 @@ if [[ -n "${DOCKER_TAG}" ]] && [[ "${DOCKER_TAG}" != "latest" ]]; then
     # Derive the BASE_IMAGE from the DOCKER_TAG
     if [[ $DOCKER_TAG =~ ^r-base- ]]; then
         BASE_IMAGE=$(echo "${DOCKER_TAG}" | sed 's/^r-base-/r-base:/')
+        BUILD_TARGET="gdal"
     elif [[ $DOCKER_TAG =~ ^rocker-r- ]]; then
         BASE_IMAGE=$(echo "${DOCKER_TAG}" | sed 's/\-/:/3' | sed 's|\-|/|1')
+        BUILD_TARGET="gdal"
     else
         BASE_IMAGE=$(echo "${DOCKER_TAG}" | sed 's/\-/:/1')
     fi
-fi
-
-BUILD_TARGET="default"
-if [[ $BASE_IMAGE =~ python ]]; then
-    BUILD_TARGET="python"
 fi
 
 # Build our customised docker image

--- a/python/pip3-netcdf-install.sh
+++ b/python/pip3-netcdf-install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # This script can be called to ensure that python libraries corresponding with
 # the C and C++ libraries we have installed from source are installed AND
@@ -14,10 +15,13 @@ if [[ -z "${REQUIREMENTS_TXT}" ]] || [[ ! -f "${REQUIREMENTS_TXT}" ]]; then
     REQUIREMENTS_TXT="${THIS_DIR}/requirements.txt"
 fi
 
+pip3 install --upgrade \
+	pip wheel setuptools
+
 pip3 install \
 	--constraint "${REQUIREMENTS_TXT}" \
 	--no-binary mpi4py \
-	mpi4py Cython
+	mpi4py numpy Cython
 
 CPATH="${MPI_INCLUDE_PATH}" pip3 install \
 	--constraint "${REQUIREMENTS_TXT}" \

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,5 +2,6 @@ Cython==3.0.8
 mpi4py==3.1.5
 nco==1.1.0
 netcdf4==1.6.5
+numpy==1.26.2
 pydap==3.4.1
 pyproj==3.6.1


### PR DESCRIPTION
The patch application via a relative-path bind-mount of the patches directory was failing for automated builds because those don't have the Dockerfile context as their CWD, so the bind-mount path was incorrect.

Having the source directories mounted as build-cache was also causing concern: the source files not being present in the image did make it smaller, but limited developers' ability to re-build or run tests... or be sure that all linked headers and libs were present.

This changeset works around both of these by switching build-caching to only be used for downloaded tarballs, not for the unpacked source code.  The NetCDF patch is now optional (controlled via a build-arg) and applied via standard means in a way that is less likely to cause issues with subsequent runs.

The pip3-netcdf-install script now includes numpy as a netcdf dependency, and is NOT run in the image by default: this allows users of derived images to call the script with their own requirements file, and fixes https://github.com/eReefs/netcdf-base/issues/3